### PR TITLE
Preventing duplicate registrations with hashed email addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj
 .DS_Store
 *.user
 .editorconfig
+.vs

--- a/src/Example.Web/Example.Web.csproj
+++ b/src/Example.Web/Example.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -8,12 +8,13 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Adliance.Buddy.Crypto" Version="8.0.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-        <PackageReference Include="Adliance.Buddy.CodeStyle" Version="8.0.0.8"/>
+        <PackageReference Include="Adliance.Buddy.CodeStyle" Version="8.0.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/Example.Web/Factories/ViewModels/Home/IndexViewModelFactory.cs
+++ b/src/Example.Web/Factories/ViewModels/Home/IndexViewModelFactory.cs
@@ -1,5 +1,7 @@
 using Example.Web.Models.Database;
 using Example.Web.ViewModels.Home;
+using Adliance.Buddy.Crypto;
+using Microsoft.EntityFrameworkCore;
 
 namespace Example.Web.Factories.ViewModels.Home;
 
@@ -12,17 +14,33 @@ public class IndexViewModelFactory(ILogger<IndexViewModelFactory> logger, Db db)
 
     public async Task<IndexViewModel> HandleRegistrationAsync(IndexViewModel viewModel)
     {
-        var registration = new Registration
-        {
-            FirstName = viewModel.FirstName,
-            LastName = viewModel.LastName,
-            CreatedUtc = DateTime.UtcNow
-        };
-        db.Registrations.Add(registration);
-        await db.SaveChangesAsync();
-        viewModel.ShowSuccessMessage = true;
+        var emailSalt = string.Empty;
+        var emailHash = Crypto.HashV2(viewModel.EmailAddress, out emailSalt);
 
-        logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} stored in database with ID {registration.Id}.");
+        var hashValues = (await db.Registrations.ToListAsync()).Select(r => (r.EmailHash, r.EmailHashSalt));
+        if (hashValues.Any(r => Crypto.VerifyHashV2(viewModel.EmailAddress, r.EmailHash, r.EmailHashSalt)))
+        {
+            viewModel.ShowErrorMessage = true;
+            logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} was denied. EmailAddress address is already in use.");
+        }
+
+        else
+        {
+            var registration = new Registration
+            {
+                EmailHash = emailHash,
+                EmailHashSalt = emailSalt,
+                FirstName = viewModel.FirstName,
+                LastName = viewModel.LastName,
+                CreatedUtc = DateTime.UtcNow
+            };
+            db.Registrations.Add(registration);
+            await db.SaveChangesAsync();
+            viewModel.ShowSuccessMessage = true;
+
+            logger.LogInformation($"Registration of {viewModel.FirstName} {viewModel.LastName} stored in database with ID {registration.Id}.");
+        }
+
         return viewModel;
     }
 }

--- a/src/Example.Web/Migrations/20241202163845_AddEmailHashAndSalt.Designer.cs
+++ b/src/Example.Web/Migrations/20241202163845_AddEmailHashAndSalt.Designer.cs
@@ -4,6 +4,7 @@ using Example.Web.Models.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Example.Web.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20241202163845_AddEmailHashAndSalt")]
+    partial class AddEmailHashAndSalt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Example.Web/Migrations/20241202163845_AddEmailHashAndSalt.cs
+++ b/src/Example.Web/Migrations/20241202163845_AddEmailHashAndSalt.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Example.Web.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailHashAndSalt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailHash",
+                table: "Registrations",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "EmailHashSalt",
+                table: "Registrations",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailHash",
+                table: "Registrations");
+
+            migrationBuilder.DropColumn(
+                name: "EmailHashSalt",
+                table: "Registrations");
+        }
+    }
+}

--- a/src/Example.Web/Models/Database/Registration.cs
+++ b/src/Example.Web/Models/Database/Registration.cs
@@ -6,4 +6,6 @@ public class Registration
     public string FirstName { get; set; } = "";
     public string LastName { get; set; } = "";
     public DateTime CreatedUtc { get; set; }
+    public string EmailHash { get; set; } = "";
+    public string EmailHashSalt { get; set; } = "";
 }

--- a/src/Example.Web/ViewModels/Home/IndexViewModel.cs
+++ b/src/Example.Web/ViewModels/Home/IndexViewModel.cs
@@ -4,7 +4,9 @@ namespace Example.Web.ViewModels.Home;
 
 public class IndexViewModel
 {
+    [Required] public string EmailAddress { get; set; } = "";
     [Required] public string FirstName { get; set; } = "";
     [Required] public string LastName { get; set; } = "";
     public bool ShowSuccessMessage { get; set; }
+    public bool ShowErrorMessage { get; set; }
 }

--- a/src/Example.Web/Views/Home/Index.cshtml
+++ b/src/Example.Web/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model Example.Web.ViewModels.Home.IndexViewModel
+@model Example.Web.ViewModels.Home.IndexViewModel
 
 <div class="text-center">
     <h1 class="display-4">Please register</h1>
@@ -11,7 +11,19 @@
     </div>
 }
 
+@if (Model.ShowErrorMessage)
+{
+    <div class="alert alert-danger mt-5 mb-3" role="alert">
+        Registration failed. Your email address is already in use.
+    </div>
+}
+
 <form method="post">
+    <div class="form-group">
+        <label asp-for="EmailAddress">Your email address:</label>
+        <input asp-for="EmailAddress" class="form-control" placeholder="eg. steve.jobs@mail.com">
+        <span asp-validation-for="EmailAddress"></span>
+    </div>
     <div class="form-group">
         <label asp-for="FirstName">Your first name:</label>
         <input asp-for="FirstName" class="form-control" placeholder="eg. Steve">

--- a/test/Example.Web.Tests/Controllers/HomeControllerTests.cs
+++ b/test/Example.Web.Tests/Controllers/HomeControllerTests.cs
@@ -1,8 +1,5 @@
 using System.Net;
-using System.Net.Http.Json;
-using Example.Web.Controllers;
 using Example.Web.Models.Database;
-using Example.Web.ViewModels.Home;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,7 +35,7 @@ public class HomeControllerTests : IClassFixture<WebApplicationFactory<Program>>
         using var httpClient = _factory.CreateClient();
         var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
         {
-            new("FirstName", "Some first name"), new("LastName", "Some last name")
+            new("FirstName", "Some first name"), new("LastName", "Some last name"), new("EmailAddress", "Some email")
         }));
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
@@ -47,5 +44,23 @@ public class HomeControllerTests : IClassFixture<WebApplicationFactory<Program>>
         var registration = await _db.Registrations.SingleAsync();
         Assert.Equal("Some first name", registration.FirstName);
         Assert.Equal("Some last name", registration.LastName);
+    }
+
+    [Fact]
+    public async Task Post_Will_Not_Store_Registration_If_Email_Already_Used()
+    {
+        using var httpClient = _factory.CreateClient();
+        var response = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", "Some first name"), new("LastName", "Some last name"), new("EmailAddress", "Some email")
+        }));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseError = await httpClient.PostAsync("/", new FormUrlEncodedContent(new KeyValuePair<string, string>[]
+        {
+            new("FirstName", "Some first name2"), new("LastName", "Some last name2"), new("EmailAddress", "Some email")
+        }));
+
+        Assert.Single(await _db.Registrations.ToListAsync());
     }
 }


### PR DESCRIPTION
To prevent duplicate user registrations, the email address is required.  For privacy reasons, and because the email address serves solely as a unique identifier it is only stored as hash.